### PR TITLE
Deal with FSC validation for lead company matching name

### DIFF
--- a/force-app/main/default/classes/DML_Test.cls
+++ b/force-app/main/default/classes/DML_Test.cls
@@ -1167,6 +1167,7 @@ private class DML_Test {
 			account1.Name = 'Updated Test Account';
 			opportunity1.Name = 'Updated Test Opportunity';
 			lead1.FirstName = 'Updated Test';
+			lead1.Company = 'Updated Test Lead 1';
 
 			DML.Result result = new DML()
 				.toUpdate(account1)
@@ -6200,7 +6201,7 @@ private class DML_Test {
 	}
 
 	static Lead getLead(Integer index) {
-		return new Lead(FirstName = 'Test ' + index, LastName = 'Lead ' + index, Company = 'Test Company ' + index);
+		return new Lead(FirstName = 'Test ' + index, LastName = 'Lead ' + index, Company = 'Test ' + index + ' Lead ' + index);
 	}
 
 	static Case getCase(Integer index) {


### PR DESCRIPTION
## Description

Bit of a specific edge case, FSC has a bug on leads which requires Name to equal Company but only from test context... Any org with FSC would have issues with the DML_Test class

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Changes Made

<!-- List the specific changes made in this PR -->

- Update DML_Test such that lead name and company are equal. As there is no real test on the data and it's only populated because it's required, I think this is safe to merge.
-
-

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Closes #

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] All existing tests pass (`npm test`)
- [ ] Added new tests for new functionality
- [x] Tested in scratch org
- [ ] Linting passes (`npm run lint`)
- [ ] Code formatting is correct (`npm run prettier:verify`)

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional information that reviewers should know -->
