### PR TITLE
Populate RecordSummary's record in executeMockedDml

### DIFF
--- a/force-app/main/default/classes/DML.cls
+++ b/force-app/main/default/classes/DML.cls
@@ -1246,7 +1246,7 @@ global inherited sharing class DML implements Commitable {
 
 		protected override RecordSummary executeMockedDml(SObject record) {
 			record.put('Id', randomIdGenerator.get(record.getSObjectType()));
-			return new RecordSummary().isSuccess(true).recordId(record.Id);
+			return new RecordSummary().isSuccess(true).recordId(record.Id).record(record);
 		}
 	}
 
@@ -1287,7 +1287,7 @@ global inherited sharing class DML implements Commitable {
 			if (record.Id == null) {
 				record.put('Id', randomIdGenerator.get(record.getSObjectType()));
 			}
-			return new RecordSummary().isSuccess(true).recordId(record.Id);
+			return new RecordSummary().isSuccess(true).recordId(record.Id).record(record);
 		}
 	}
 
@@ -1315,7 +1315,7 @@ global inherited sharing class DML implements Commitable {
 		}
 
 		protected override RecordSummary executeMockedDml(SObject record) {
-			return new RecordSummary().isSuccess(true).recordId(record.Id);
+			return new RecordSummary().isSuccess(true).recordId(record.Id).record(record);
 		}
 	}
 
@@ -1351,7 +1351,7 @@ global inherited sharing class DML implements Commitable {
 		}
 
 		protected override RecordSummary executeMockedDml(SObject record) {
-			return new RecordSummary().isSuccess(true).recordId(record.Id);
+			return new RecordSummary().isSuccess(true).recordId(record.Id).record(record);
 		}
 	}
 
@@ -1396,7 +1396,7 @@ global inherited sharing class DML implements Commitable {
 		}
 
 		protected override RecordSummary executeMockedDml(SObject record) {
-			return new RecordSummary().isSuccess(true).recordId(record.Id);
+			return new RecordSummary().isSuccess(true).recordId(record.Id).record(record);
 		}
 	}
 
@@ -1424,7 +1424,7 @@ global inherited sharing class DML implements Commitable {
 		}
 
 		protected override RecordSummary executeMockedDml(SObject record) {
-			return new RecordSummary().isSuccess(true).recordId(record.Id);
+			return new RecordSummary().isSuccess(true).recordId(record.Id).record(record);
 		}
 	}
 
@@ -1446,7 +1446,7 @@ global inherited sharing class DML implements Commitable {
 		}
 
 		protected override RecordSummary executeMockedDml(SObject record) {
-			return new RecordSummary().isSuccess(true).recordId(randomIdGenerator.get(record.getSObjectType()));
+			return new RecordSummary().isSuccess(true).recordId(randomIdGenerator.get(record.getSObjectType())).record(record);
 		}
 	}
 
@@ -1919,7 +1919,8 @@ global inherited sharing class DML implements Commitable {
 			for (SObject record : recordsToProcess) {
 				RecordSummary recordSummary = new RecordSummary()
 					.isSuccess(false)
-					.error(new RecordProcessingError().setMessage(errorMessage).setStatusCode(System.StatusCode.ALREADY_IN_PROCESS).setFields(new List<String>{ 'Id' }));
+					.error(new RecordProcessingError().setMessage(errorMessage).setStatusCode(System.StatusCode.ALREADY_IN_PROCESS).setFields(new List<String>{ 'Id' }))
+					.record(record);
 
 				recordResults.add(recordSummary);
 			}

--- a/force-app/main/default/classes/DML_Test.cls
+++ b/force-app/main/default/classes/DML_Test.cls
@@ -547,6 +547,8 @@ private class DML_Test {
 		Assert.areEqual(1, result.insertsOf(Account.SObjectType).recordResults().size(), 'Inserted operation result should contain the inserted record results.');
 		Assert.isTrue(result.insertsOf(Account.SObjectType).recordResults()[0].isSuccess(), 'Inserted operation result should contain a successful record result.');
 		Assert.isNotNull(result.insertsOf(Account.SObjectType).recordResults()[0].id(), 'Inserted operation result should contain a mocked record Id.');
+		Assert.isNotNull(result.insertsOf(Account.SObjectType).recordResults()[0].record(), 'Inserted operation record result should contain the record.');
+		Assert.areEqual(account1.Id, result.insertsOf(Account.SObjectType).recordResults()[0].record().Id, 'Record result should return the mocked record.');
 		Assert.isNotNull(account1.Id, 'Account should have mocked Id.');
 	}
 


### PR DESCRIPTION
## Description

- Populate RecordResult.record() for mocked DML outcomes so the original SObject is available (success and error mocks).
- Add a unit test assertion verifying record() returns the mocked record and Id.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Changes Made

- Update executeMockedDml methods to 
- getMockedRecordErrors


## Related Issues

N/A

Fixes #
Closes #

## Testing

- [ ] All existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [x] Tested in scratch org
- [ ] Linting passes (`npm run lint`)
- [ ] Code formatting is correct (`npm run prettier:verify`)

## Screenshots


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional information that reviewers should know -->
