### PR TITLE
Feature/add with mode global method

### DIFF
--- a/force-app/main/default/classes/DML.cls
+++ b/force-app/main/default/classes/DML.cls
@@ -126,7 +126,7 @@ public inherited sharing class DML implements Commitable {
         // Field Level Security
         Commitable userMode();
         Commitable systemMode();
-        Commitable withMode(System.AccessLevel accessMode);
+        Commitable accessMode(System.AccessLevel accessMode);
         // Sharing Mode
         Commitable withSharing();
         Commitable withoutSharing();
@@ -670,18 +670,16 @@ public inherited sharing class DML implements Commitable {
     // Field Level Security
 
     public Commitable userMode() {
-        return this.setAccessMode(System.AccessLevel.USER_MODE);
+        this.configuration.accessMode(System.AccessLevel.USER_MODE);
+        return this;
     }
 
     public Commitable systemMode() {
-        return this.setAccessMode(System.AccessLevel.SYSTEM_MODE);
+        this.configuration.accessMode(System.AccessLevel.SYSTEM_MODE);
+        return this;
     }
 
-    public Commitable withMode(System.AccessLevel accessMode) {
-        return this.setAccessMode(accessMode);
-    }
-
-    private Commitable setAccessMode(System.AccessLevel accessMode) {
+    public Commitable accessMode(System.AccessLevel accessMode) {
         this.configuration.accessMode(accessMode);
         return this;
     }

--- a/force-app/main/default/classes/DML.cls
+++ b/force-app/main/default/classes/DML.cls
@@ -126,6 +126,7 @@ public inherited sharing class DML implements Commitable {
         // Field Level Security
         Commitable userMode();
         Commitable systemMode();
+        Commitable withMode(System.AccessLevel accessMode);
         // Sharing Mode
         Commitable withSharing();
         Commitable withoutSharing();
@@ -674,6 +675,10 @@ public inherited sharing class DML implements Commitable {
 
     public Commitable systemMode() {
         return this.setAccessMode(System.AccessLevel.SYSTEM_MODE);
+    }
+
+    public Commitable withMode(System.AccessLevel accessMode) {
+        return this.setAccessMode(accessMode);
     }
 
     private Commitable setAccessMode(System.AccessLevel accessMode) {

--- a/force-app/main/default/classes/DML_Test.cls
+++ b/force-app/main/default/classes/DML_Test.cls
@@ -3532,7 +3532,28 @@ private class DML_Test {
         Assert.areEqual('Access to entity \'Case\' denied', expectedException.getMessage(), 'Expected exception message should be thrown.');
     }
 
+    @IsTest
+    static void toInsertWithUserModeExplicitlySetWithMode() {
+        // Setup
+        Case newCase = getCase(1);
 
+        Exception expectedException = null;
+
+        // Test
+        Test.startTest();
+        System.runAs(minimumAccessUser()) {
+            try {
+                new DML().toInsert(newCase).withMode(System.AccessLevel.USER_MODE).commitWork();
+            } catch (Exception e) {
+                expectedException = e;
+            }
+        }
+        Test.stopTest();
+
+        // Verify
+        Assert.isNotNull(expectedException, 'Expected exception to be thrown.');
+        Assert.areEqual('Access to entity \'Case\' denied', expectedException.getMessage(), 'Expected exception message should be thrown.');
+    }
 
     @IsTest
     static void toInsertWithInvalidRelationshipSingleRecord() {

--- a/force-app/main/default/classes/DML_Test.cls
+++ b/force-app/main/default/classes/DML_Test.cls
@@ -3533,7 +3533,7 @@ private class DML_Test {
     }
 
     @IsTest
-    static void toInsertWithUserModeExplicitlySetWithMode() {
+    static void toInsertWithUserModeExplicitlySetAccessMode() {
         // Setup
         Case newCase = getCase(1);
 
@@ -3543,7 +3543,7 @@ private class DML_Test {
         Test.startTest();
         System.runAs(minimumAccessUser()) {
             try {
-                new DML().toInsert(newCase).withMode(System.AccessLevel.USER_MODE).commitWork();
+                new DML().toInsert(newCase).accessMode(System.AccessLevel.USER_MODE).commitWork();
             } catch (Exception e) {
                 expectedException = e;
             }

--- a/package/main/default/classes/DML.cls
+++ b/package/main/default/classes/DML.cls
@@ -126,7 +126,7 @@ global inherited sharing class DML implements Commitable {
         // Field Level Security
         Commitable userMode();
         Commitable systemMode();
-        Commitable withMode(System.AccessLevel accessMode);
+        Commitable accessMode(System.AccessLevel accessMode);
         // Sharing Mode
         Commitable withSharing();
         Commitable withoutSharing();
@@ -670,18 +670,16 @@ global inherited sharing class DML implements Commitable {
     // Field Level Security
 
     global Commitable userMode() {
-        return this.setAccessMode(System.AccessLevel.USER_MODE);
+        this.configuration.accessMode(System.AccessLevel.USER_MODE);
+        return this;
     }
 
     global Commitable systemMode() {
-        return this.setAccessMode(System.AccessLevel.SYSTEM_MODE);
+        this.configuration.accessMode(System.AccessLevel.SYSTEM_MODE);
+        return this;
     }
 
-    global Commitable withMode(System.AccessLevel accessMode) {
-        return this.setAccessMode(accessMode);
-    }
-
-    private Commitable setAccessMode(System.AccessLevel accessMode) {
+    global Commitable accessMode(System.AccessLevel accessMode) {
         this.configuration.accessMode(accessMode);
         return this;
     }

--- a/package/main/default/classes/DML.cls
+++ b/package/main/default/classes/DML.cls
@@ -126,6 +126,7 @@ global inherited sharing class DML implements Commitable {
         // Field Level Security
         Commitable userMode();
         Commitable systemMode();
+        Commitable withMode(System.AccessLevel accessMode);
         // Sharing Mode
         Commitable withSharing();
         Commitable withoutSharing();
@@ -674,6 +675,10 @@ global inherited sharing class DML implements Commitable {
 
     global Commitable systemMode() {
         return this.setAccessMode(System.AccessLevel.SYSTEM_MODE);
+    }
+
+    global Commitable withMode(System.AccessLevel accessMode) {
+        return this.setAccessMode(accessMode);
     }
 
     private Commitable setAccessMode(System.AccessLevel accessMode) {

--- a/package/main/default/classes/DML_Full_Test.cls
+++ b/package/main/default/classes/DML_Full_Test.cls
@@ -6854,6 +6854,29 @@ private class DML_Full_Test {
     }
 
     @IsTest
+    static void toInsertWithUserModeExplicitlySetWithMode() {
+        // Setup
+        Case newCase = getCase(1);
+
+        Exception expectedException = null;
+
+        // Test
+        Test.startTest();
+        System.runAs(minimumAccessUser()) {
+            try {
+                new DML().toInsert(newCase).withMode(System.AccessLevel.USER_MODE).commitWork();
+            } catch (Exception e) {
+                expectedException = e;
+            }
+        }
+        Test.stopTest();
+
+        // Verify
+        Assert.isNotNull(expectedException, 'Expected exception to be thrown.');
+        Assert.areEqual('Access to entity \'Case\' denied', expectedException.getMessage(), 'Expected exception message should be thrown.');
+    }
+
+    @IsTest
     static void toUpdateWithUserMode() {
         // Setup
         Case newCase = getCase(1);
@@ -6892,6 +6915,31 @@ private class DML_Full_Test {
             try {
                 newCase.Subject = 'Updated Test Case';
                 new DML().toUpdate(newCase).userMode().commitWork();
+            } catch (Exception e) {
+                expectedException = e;
+            }
+        }
+        Test.stopTest();
+
+        // Verify
+        Assert.isNotNull(expectedException, 'Expected exception to be thrown.');
+        Assert.areEqual('Access to entity \'Case\' denied', expectedException.getMessage(), 'Expected exception message should be thrown.');
+    }
+
+    @IsTest
+    static void toUpdateWithUserModeExplicitlySetWithMode() {
+        // Setup
+        Case newCase = getCase(1);
+        insert newCase;
+
+        Exception expectedException = null;
+
+        // Test
+        Test.startTest();
+        System.runAs(minimumAccessUser()) {
+            try {
+                newCase.Subject = 'Updated Test Case';
+                new DML().toUpdate(newCase).withMode(System.AccessLevel.USER_MODE).commitWork();
             } catch (Exception e) {
                 expectedException = e;
             }
@@ -6966,6 +7014,37 @@ private class DML_Full_Test {
     }
 
     @IsTest
+    static void toUpsertWithUserModeExplicitlySetWithMode() {
+        // Setup
+        Case newCase1 = getCase(1);
+        Case newCase2 = getCase(2);
+
+        insert newCase1;
+
+        Exception expectedException = null;
+
+        // Test
+        Test.startTest();
+        System.runAs(minimumAccessUser()) {
+            try {
+                newCase1.Subject = 'Updated Test Case';
+
+                new DML().toUpsert(newCase1).toUpsert(newCase2).withMode(System.AccessLevel.USER_MODE).commitWork();
+            } catch (Exception e) {
+                expectedException = e;
+            }
+        }
+        Test.stopTest();
+
+        // Verify
+        Assert.isNotNull(expectedException, 'Expected exception to be thrown.');
+        Assert.isTrue(
+            expectedException.getMessage().contains('Operation failed due to fields being inaccessible on Sobject Case, check errors on Exception or Result'),
+            'Expected exception message should be thrown.'
+        );
+    }
+
+    @IsTest
     static void toDeleteWithUserMode() {
         // Setup
         Case newCase = getCase(1);
@@ -7002,6 +7081,30 @@ private class DML_Full_Test {
         System.runAs(minimumAccessUser()) {
             try {
                 new DML().toDelete(newCase).userMode().commitWork();
+            } catch (Exception e) {
+                expectedException = e;
+            }
+        }
+        Test.stopTest();
+
+        // Verify
+        Assert.isNotNull(expectedException, 'Expected exception to be thrown.');
+        Assert.areEqual('Access to entity \'Case\' denied', expectedException.getMessage(), 'Expected exception message should be thrown.');
+    }
+
+    @IsTest
+    static void toDeleteWithUserModeExplicitlySetWithMode() {
+        // Setup
+        Case newCase = getCase(1);
+        insert newCase;
+
+        Exception expectedException = null;
+
+        // Test
+        Test.startTest();
+        System.runAs(minimumAccessUser()) {
+            try {
+                new DML().toDelete(newCase).withMode(System.AccessLevel.USER_MODE).commitWork();
             } catch (Exception e) {
                 expectedException = e;
             }
@@ -7100,6 +7203,34 @@ private class DML_Full_Test {
         System.runAs(minimumAccessUser()) {
             try {
                 new DML().toUndelete(newCase).userMode().commitWork();
+            } catch (Exception e) {
+                expectedException = e;
+            }
+        }
+        Test.stopTest();
+
+        // Verify
+        Assert.isNotNull(expectedException, 'Expected exception to be thrown.');
+        Assert.isTrue(expectedException.getMessage().contains('invalid record id'), 'Expected exception message should be thrown.');
+    }
+
+    @IsTest
+    static void toUndeleteWithUserModeExplicitlySetWithMode() {
+        // Setup
+        Case newCase = getCase(1);
+        insert newCase;
+
+        delete newCase;
+
+        Assert.areEqual(0, [SELECT COUNT() FROM Case], 'Cases should be deleted.');
+
+        Exception expectedException = null;
+
+        // Test
+        Test.startTest();
+        System.runAs(minimumAccessUser()) {
+            try {
+                new DML().toUndelete(newCase).withMode(System.AccessLevel.USER_MODE).commitWork();
             } catch (Exception e) {
                 expectedException = e;
             }

--- a/package/main/default/classes/DML_Full_Test.cls
+++ b/package/main/default/classes/DML_Full_Test.cls
@@ -6854,7 +6854,7 @@ private class DML_Full_Test {
     }
 
     @IsTest
-    static void toInsertWithUserModeExplicitlySetWithMode() {
+    static void toInsertWithUserModeExplicitlySetAccessMode() {
         // Setup
         Case newCase = getCase(1);
 
@@ -6864,7 +6864,7 @@ private class DML_Full_Test {
         Test.startTest();
         System.runAs(minimumAccessUser()) {
             try {
-                new DML().toInsert(newCase).withMode(System.AccessLevel.USER_MODE).commitWork();
+                new DML().toInsert(newCase).accessMode(System.AccessLevel.USER_MODE).commitWork();
             } catch (Exception e) {
                 expectedException = e;
             }
@@ -6927,7 +6927,7 @@ private class DML_Full_Test {
     }
 
     @IsTest
-    static void toUpdateWithUserModeExplicitlySetWithMode() {
+    static void toUpdateWithUserModeExplicitlySetAccessMode() {
         // Setup
         Case newCase = getCase(1);
         insert newCase;
@@ -6939,7 +6939,7 @@ private class DML_Full_Test {
         System.runAs(minimumAccessUser()) {
             try {
                 newCase.Subject = 'Updated Test Case';
-                new DML().toUpdate(newCase).withMode(System.AccessLevel.USER_MODE).commitWork();
+                new DML().toUpdate(newCase).accessMode(System.AccessLevel.USER_MODE).commitWork();
             } catch (Exception e) {
                 expectedException = e;
             }
@@ -7014,7 +7014,7 @@ private class DML_Full_Test {
     }
 
     @IsTest
-    static void toUpsertWithUserModeExplicitlySetWithMode() {
+    static void toUpsertWithUserModeExplicitlySetAccessMode() {
         // Setup
         Case newCase1 = getCase(1);
         Case newCase2 = getCase(2);
@@ -7029,7 +7029,7 @@ private class DML_Full_Test {
             try {
                 newCase1.Subject = 'Updated Test Case';
 
-                new DML().toUpsert(newCase1).toUpsert(newCase2).withMode(System.AccessLevel.USER_MODE).commitWork();
+                new DML().toUpsert(newCase1).toUpsert(newCase2).accessMode(System.AccessLevel.USER_MODE).commitWork();
             } catch (Exception e) {
                 expectedException = e;
             }
@@ -7093,7 +7093,7 @@ private class DML_Full_Test {
     }
 
     @IsTest
-    static void toDeleteWithUserModeExplicitlySetWithMode() {
+    static void toDeleteWithUserModeExplicitlySetAccessMode() {
         // Setup
         Case newCase = getCase(1);
         insert newCase;
@@ -7104,7 +7104,7 @@ private class DML_Full_Test {
         Test.startTest();
         System.runAs(minimumAccessUser()) {
             try {
-                new DML().toDelete(newCase).withMode(System.AccessLevel.USER_MODE).commitWork();
+                new DML().toDelete(newCase).accessMode(System.AccessLevel.USER_MODE).commitWork();
             } catch (Exception e) {
                 expectedException = e;
             }
@@ -7215,7 +7215,7 @@ private class DML_Full_Test {
     }
 
     @IsTest
-    static void toUndeleteWithUserModeExplicitlySetWithMode() {
+    static void toUndeleteWithUserModeExplicitlySetAccessMode() {
         // Setup
         Case newCase = getCase(1);
         insert newCase;
@@ -7230,7 +7230,7 @@ private class DML_Full_Test {
         Test.startTest();
         System.runAs(minimumAccessUser()) {
             try {
-                new DML().toUndelete(newCase).withMode(System.AccessLevel.USER_MODE).commitWork();
+                new DML().toUndelete(newCase).accessMode(System.AccessLevel.USER_MODE).commitWork();
             } catch (Exception e) {
                 expectedException = e;
             }

--- a/website/configuration/field-level-security.md
+++ b/website/configuration/field-level-security.md
@@ -17,6 +17,39 @@ System.runAs(minimalAccessUser) {
 }
 ```
 
+## withMode
+
+Set access mode explicitly using the Salesforce `System.AccessLevel` enum.
+
+**Signature**
+
+```apex
+Commitable withMode(System.AccessLevel accessMode);
+```
+
+Use `withMode(System.AccessLevel.USER_MODE)` as an alternative to `userMode()`, and `withMode(System.AccessLevel.SYSTEM_MODE)` as an alternative to `systemMode()`.
+
+**Standard DML**
+
+```apex
+insert as user new Account(Name = 'My Account');
+insert as system new Case(Subject = 'System Mode Case');
+```
+
+**DML Lib**
+
+```apex
+new DML()
+    .toInsert(new Account(Name = 'My Account'))
+    .withMode(System.AccessLevel.USER_MODE)
+    .commitWork();
+
+new DML()
+    .toInsert(new Case(Subject = 'System Mode Case'))
+    .withMode(System.AccessLevel.SYSTEM_MODE)
+    .commitWork();
+```
+
 ## userMode
 
 Execute DML operations respecting user permissions. This is the **default behavior**.
@@ -78,10 +111,13 @@ Field-level security and sharing mode are independent settings that work togethe
 | Configuration | FLS | Sharing Rules |
 |---------------|-----|---------------|
 | `userMode()` | Enforced | Enforced |
+| `withMode(System.AccessLevel.USER_MODE)` | Enforced | Enforced |
 | `userMode().withSharing()` | Enforced | Enforced |
 | `userMode().withoutSharing()` | Enforced | Enforced |
 | `systemMode().withSharing()` | Bypassed | Enforced |
+| `withMode(System.AccessLevel.SYSTEM_MODE).withSharing()` | Bypassed | Enforced |
 | `systemMode().withoutSharing()` | Bypassed | Bypassed |
+| `withMode(System.AccessLevel.SYSTEM_MODE).withoutSharing()` | Bypassed | Bypassed |
 
 **Example**
 

--- a/website/configuration/field-level-security.md
+++ b/website/configuration/field-level-security.md
@@ -17,17 +17,17 @@ System.runAs(minimalAccessUser) {
 }
 ```
 
-## withMode
+## accessMode
 
 Set access mode explicitly using the Salesforce `System.AccessLevel` enum.
 
 **Signature**
 
 ```apex
-Commitable withMode(System.AccessLevel accessMode);
+Commitable accessMode(System.AccessLevel accessMode);
 ```
 
-Use `withMode(System.AccessLevel.USER_MODE)` as an alternative to `userMode()`, and `withMode(System.AccessLevel.SYSTEM_MODE)` as an alternative to `systemMode()`.
+Use `accessMode(System.AccessLevel.USER_MODE)` as an alternative to `userMode()`, and `accessMode(System.AccessLevel.SYSTEM_MODE)` as an alternative to `systemMode()`.
 
 **Standard DML**
 
@@ -41,12 +41,12 @@ insert as system new Case(Subject = 'System Mode Case');
 ```apex
 new DML()
     .toInsert(new Account(Name = 'My Account'))
-    .withMode(System.AccessLevel.USER_MODE)
+    .accessMode(System.AccessLevel.USER_MODE)
     .commitWork();
 
 new DML()
     .toInsert(new Case(Subject = 'System Mode Case'))
-    .withMode(System.AccessLevel.SYSTEM_MODE)
+    .accessMode(System.AccessLevel.SYSTEM_MODE)
     .commitWork();
 ```
 
@@ -108,16 +108,16 @@ Use `systemMode()` with caution. It bypasses field-level security, which could e
 
 Field-level security and sharing mode are independent settings that work together.
 
-| Configuration | FLS | Sharing Rules |
-|---------------|-----|---------------|
-| `userMode()` | Enforced | Enforced |
-| `withMode(System.AccessLevel.USER_MODE)` | Enforced | Enforced |
-| `userMode().withSharing()` | Enforced | Enforced |
-| `userMode().withoutSharing()` | Enforced | Enforced |
-| `systemMode().withSharing()` | Bypassed | Enforced |
-| `withMode(System.AccessLevel.SYSTEM_MODE).withSharing()` | Bypassed | Enforced |
-| `systemMode().withoutSharing()` | Bypassed | Bypassed |
-| `withMode(System.AccessLevel.SYSTEM_MODE).withoutSharing()` | Bypassed | Bypassed |
+| Configuration                                                 | FLS      | Sharing Rules |
+| ------------------------------------------------------------- | -------- | ------------- |
+| `userMode()`                                                  | Enforced | Enforced      |
+| `accessMode(System.AccessLevel.USER_MODE)`                    | Enforced | Enforced      |
+| `userMode().withSharing()`                                    | Enforced | Enforced      |
+| `userMode().withoutSharing()`                                 | Enforced | Enforced      |
+| `systemMode().withSharing()`                                  | Bypassed | Enforced      |
+| `accessMode(System.AccessLevel.SYSTEM_MODE).withSharing()`    | Bypassed | Enforced      |
+| `systemMode().withoutSharing()`                               | Bypassed | Bypassed      |
+| `accessMode(System.AccessLevel.SYSTEM_MODE).withoutSharing()` | Bypassed | Bypassed      |
 
 **Example**
 

--- a/website/configuration/sharing-mode.md
+++ b/website/configuration/sharing-mode.md
@@ -42,7 +42,7 @@ We suggest using `.systemMode().withoutSharing()` in triggers, as trigger logic 
 
 By default, the DML library uses `with sharing`, meaning it respects the sharing context of the calling class. 
 Sharing mode is enforced by `userMode()`, which is the default mode.
-Only when `.systemMode()` is used, `.withSharing()` can control the sharing mode.
+Only when `.systemMode()` or `.withMode(System.AccessLevel.SYSTEM_MODE)` is used, `.withSharing()` can control the sharing mode.
 
 Execute DML operations enforcing sharing rules. Records the user doesn't have access to will cause errors.
 
@@ -76,7 +76,7 @@ new DML()
 ## withoutSharing
 
 Execute DML operations bypassing sharing rules. All records are accessible regardless of sharing settings.
-To use `.withoutSharing()`, the `.systemMode()` must be enabled.
+To use `.withoutSharing()`, `.systemMode()` or `.withMode(System.AccessLevel.SYSTEM_MODE)` must be enabled.
 
 **Signature**
 

--- a/website/configuration/sharing-mode.md
+++ b/website/configuration/sharing-mode.md
@@ -42,7 +42,7 @@ We suggest using `.systemMode().withoutSharing()` in triggers, as trigger logic 
 
 By default, the DML library uses `with sharing`, meaning it respects the sharing context of the calling class. 
 Sharing mode is enforced by `userMode()`, which is the default mode.
-Only when `.systemMode()` or `.withMode(System.AccessLevel.SYSTEM_MODE)` is used, `.withSharing()` can control the sharing mode.
+Only when `.systemMode()` or `.accessMode(System.AccessLevel.SYSTEM_MODE)` is used, `.withSharing()` can control the sharing mode.
 
 Execute DML operations enforcing sharing rules. Records the user doesn't have access to will cause errors.
 
@@ -76,7 +76,7 @@ new DML()
 ## withoutSharing
 
 Execute DML operations bypassing sharing rules. All records are accessible regardless of sharing settings.
-To use `.withoutSharing()`, `.systemMode()` or `.withMode(System.AccessLevel.SYSTEM_MODE)` must be enabled.
+To use `.withoutSharing()`, `.systemMode()` or `.accessMode(System.AccessLevel.SYSTEM_MODE)` must be enabled.
 
 **Signature**
 

--- a/website/dml/delete.md
+++ b/website/dml/delete.md
@@ -154,7 +154,7 @@ OperationResult deleteImmediately(List<SObject> records);
 ```
 
 ::: tip
-All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `deleteImmediately`.
+All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `deleteImmediately`.
 :::
 
 ### Single Record

--- a/website/dml/delete.md
+++ b/website/dml/delete.md
@@ -154,7 +154,7 @@ OperationResult deleteImmediately(List<SObject> records);
 ```
 
 ::: tip
-All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `deleteImmediately`.
+All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `accessMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `deleteImmediately`.
 :::
 
 ### Single Record

--- a/website/dml/insert.md
+++ b/website/dml/insert.md
@@ -245,7 +245,7 @@ OperationResult insertImmediately(DML.Records records);
 ```
 
 ::: tip
-All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `insertImmediately`.
+All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `insertImmediately`.
 :::
 
 ### Single Record

--- a/website/dml/insert.md
+++ b/website/dml/insert.md
@@ -245,7 +245,7 @@ OperationResult insertImmediately(DML.Records records);
 ```
 
 ::: tip
-All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `insertImmediately`.
+All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `accessMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `insertImmediately`.
 :::
 
 ### Single Record

--- a/website/dml/undelete.md
+++ b/website/dml/undelete.md
@@ -154,7 +154,7 @@ OperationResult undeleteImmediately(List<SObject> records);
 ```
 
 ::: tip
-All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `undeleteImmediately`.
+All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `undeleteImmediately`.
 :::
 
 ### Single Record

--- a/website/dml/undelete.md
+++ b/website/dml/undelete.md
@@ -154,7 +154,7 @@ OperationResult undeleteImmediately(List<SObject> records);
 ```
 
 ::: tip
-All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `undeleteImmediately`.
+All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `accessMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `undeleteImmediately`.
 :::
 
 ### Single Record

--- a/website/dml/update.md
+++ b/website/dml/update.md
@@ -232,7 +232,7 @@ OperationResult updateImmediately(DML.Records records);
 ```
 
 ::: tip
-All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `updateImmediately`.
+All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `updateImmediately`.
 :::
 
 ### Single Record

--- a/website/dml/update.md
+++ b/website/dml/update.md
@@ -232,7 +232,7 @@ OperationResult updateImmediately(DML.Records records);
 ```
 
 ::: tip
-All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `updateImmediately`.
+All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `accessMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `updateImmediately`.
 :::
 
 ### Single Record

--- a/website/dml/upsert.md
+++ b/website/dml/upsert.md
@@ -316,7 +316,7 @@ OperationResult upsertImmediately(DML.Records records);
 ```
 
 ::: tip
-All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `upsertImmediately`.
+All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `upsertImmediately`.
 :::
 
 ### Single Record

--- a/website/dml/upsert.md
+++ b/website/dml/upsert.md
@@ -316,7 +316,7 @@ OperationResult upsertImmediately(DML.Records records);
 ```
 
 ::: tip
-All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `withMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `upsertImmediately`.
+All DML settings configured on the `DML` instance (such as `userMode()`, `systemMode()`, `accessMode(System.AccessLevel)`, `withSharing()`, `withoutSharing()`, `allowPartialSuccess()`) are inherited when executing `upsertImmediately`.
 :::
 
 ### Single Record


### PR DESCRIPTION
## Description

Add `accessMode(System.AccessLevel)` method to the DML library as an alternative to `userMode()` and `systemMode()` for controlling field-level security and access permissions. 

### Why This Change

Service layer methods often receive `System.AccessLevel` as parameters. Without this method, we had to add conditional logic in each service to map the parameter to the appropriate DML method:

```java
DML.Commitable dml = new DML();
if(accessLevel == System.AccessLevel.SYSTEM_MODE){
    dml.systemMode();
}
dml.toUpdate(recordToUpdate).commitWork();
```

With the new `accessMode()` method, services can now use the library as intended with a clean, fluent API:

```java
new DML().accessMode(accessLevel).toUpdate(recordToUpdate).commitWork()
```

This eliminates boilerplate conditional logic and allows `System.AccessLevel` to be passed directly through the DML API.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [x] Test improvements
- [ ] CI/CD improvements

## Changes Made

- Added `accessMode(System.AccessLevel accessMode)` method to DML interface and implementation class (in both unmanaged and packaged folders)
- Added comprehensive unit tests in DML_Full_Test.cls for the new accessMode() method:
  - `toInsertWithUserModeExplicitlySetAccessMode()` (added also to DML_Test.cls)
  - `toUpdateWithUserModeExplicitlySetAccessMode()`
  - `toUpsertWithUserModeExplicitlySetAccessMode()`
  - `toDeleteWithUserModeExplicitlySetAccessMode()`
  - `toUndeleteWithUserModeExplicitlySetAccessMode()`
- Updated [website/configuration/field-level-security.md](website/configuration/field-level-security.md) with dedicated `accessMode()` section explaining usage and equivalence to `userMode()/systemMode()`
- Updated [website/configuration/sharing-mode.md](website/configuration/sharing-mode.md) to clarify that `accessMode(System.AccessLevel.SYSTEM_MODE)` is an alternative to `systemMode()` when using sharing controls
- Updated immediate-operation configuration tips across all DML operation docs to include `accessMode(System.AccessLevel)`:
  - [website/dml/insert.md](website/dml/insert.md)
  - [website/dml/update.md](website/dml/update.md)
  - [website/dml/upsert.md](website/dml/upsert.md)
  - [website/dml/delete.md](website/dml/delete.md)
  - [website/dml/undelete.md](website/dml/undelete.md)

## Testing

I've run all unit tests and tested it manually in a scratch org

- [x] All existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [x] Tested in scratch org
- [x] Linting passes (`npm run lint`)
- [x] Code formatting is correct (`npm run prettier:verify`)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
