### PR TITLE
docs: enable clean URLs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
   "buildCommand": "npm run docs:build",
-  "outputDirectory": "website/.vitepress/dist"
+  "outputDirectory": "website/.vitepress/dist",
+  "cleanUrls": true
 }

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -3,6 +3,7 @@ import { withMermaid } from 'vitepress-plugin-mermaid'
 // https://vitepress.dev/reference/site-config
 
 export default withMermaid({
+  cleanUrls: true,
   title: "DML Lib",
   description: "Apex DML Lib.",
   head: [


### PR DESCRIPTION
Enables VitePress `cleanUrls` so docs pages resolve without the `.html` suffix, consistent with our other documentation sites. Adds `"cleanUrls": true` to `vercel.json` and `cleanUrls: true` to the VitePress config.