### PR TITLE
add @NamespaceAccessible to public entry points

### DIFF
--- a/force-app/main/default/classes/DML.cls
+++ b/force-app/main/default/classes/DML.cls
@@ -23,7 +23,9 @@
 @SuppressWarnings(
     'PMD.MethodNamingConventions,PMD.ApexDoc,PMD.CyclomaticComplexity,PMD.CognitiveComplexity,PMD.ExcessivePublicCount,PMD.FieldDeclarationsShouldBeAtStart,PMD.AvoidDebugStatements,PMD.OperationWithLimitsInLoop,PMD.ApexCRUDViolation,PMD.ExcessiveClassLength,PMD.NcssTypeCount,PMD.PropertyNamingConventions,PMD.FieldNamingConventions,PMD.AvoidGlobalModifier'
 )
+@NamespaceAccessible
 public inherited sharing class DML implements Commitable {
+    @NamespaceAccessible
     public static Commitable Shared {
         get {
             if (Shared == null) {
@@ -34,22 +36,27 @@ public inherited sharing class DML implements Commitable {
         private set;
     }
 
+    @NamespaceAccessible
     public static Record Record(SObject record) {
         return new DmlRecord(record);
     }
 
+    @NamespaceAccessible
     public static Record Record(Id recordId) {
         return new DmlRecord(recordId);
     }
 
+    @NamespaceAccessible
     public static Records Records(List<SObject> records) {
         return new DmlRecords(records);
     }
 
+    @NamespaceAccessible
     public static Records Records(Iterable<Id> recordIds) {
         return new DmlRecords(recordIds);
     }
 
+    @NamespaceAccessible
     public interface Commitable {
         // Insert
         Commitable toInsert(SObject record);
@@ -142,6 +149,7 @@ public inherited sharing class DML implements Commitable {
         Result commitTransaction(); // make a savepoint and rollback on exception
     }
 
+    @NamespaceAccessible
     public interface Record {
         Record with(SObjectField field, Object value);
         Record withRelationship(SObjectField targetField, SObject relatedRecord);
@@ -152,6 +160,7 @@ public inherited sharing class DML implements Commitable {
         SObjectType getSObjectType();
     }
 
+    @NamespaceAccessible
     public interface Records {
         Records with(SObjectField field, Object value);
         Records withRelationship(SObjectField targetField, SObject relatedRecord);
@@ -162,6 +171,7 @@ public inherited sharing class DML implements Commitable {
         SObjectType getSObjectType();
     }
 
+    @NamespaceAccessible
     public interface Result {
         List<OperationResult> all();
         // Per Operation
@@ -182,6 +192,7 @@ public inherited sharing class DML implements Commitable {
         OperationResult eventsOf(SObjectType objectType);
     }
 
+    @NamespaceAccessible
     public interface OperationResult {
         // Metadata
         DML.OperationType operationType();
@@ -197,6 +208,7 @@ public inherited sharing class DML implements Commitable {
         List<RecordResult> recordResults();
     }
 
+    @NamespaceAccessible
     public interface RecordResult {
         Id id();
         SObject record();
@@ -204,6 +216,7 @@ public inherited sharing class DML implements Commitable {
         List<Error> errors();
     }
 
+    @NamespaceAccessible
     public interface Error {
         String message();
         System.StatusCode statusCode();
@@ -212,6 +225,7 @@ public inherited sharing class DML implements Commitable {
 
     // Mocking
 
+    @NamespaceAccessible
     public static DML.Mockable mock(String dmlIdentifier) {
         if (!dmlIdentifierToMock.containsKey(dmlIdentifier)) {
             dmlIdentifierToMock.put(dmlIdentifier, new DmlMock());
@@ -219,6 +233,7 @@ public inherited sharing class DML implements Commitable {
         return dmlIdentifierToMock.get(dmlIdentifier);
     }
 
+    @NamespaceAccessible
     public static DML.Result retrieveResultFor(String dmlIdentifier) {
         if (!dmlIdentifierToResult.containsKey(dmlIdentifier)) {
             return new DmlResult();
@@ -226,6 +241,7 @@ public inherited sharing class DML implements Commitable {
         return dmlIdentifierToResult.get(dmlIdentifier);
     }
 
+    @NamespaceAccessible
     public interface Mockable {
         Mockable allDmls();
         // Per Operation
@@ -264,6 +280,7 @@ public inherited sharing class DML implements Commitable {
 
     // Hooks
 
+    @NamespaceAccessible
     public interface Hook {
         void before();
         void after(Result result);
@@ -271,6 +288,7 @@ public inherited sharing class DML implements Commitable {
 
     // Implementation
 
+    @NamespaceAccessible
     public enum OperationType {
         INSERT_DML,
         UPSERT_DML,
@@ -293,6 +311,7 @@ public inherited sharing class DML implements Commitable {
     private static final Map<String, Result> dmlIdentifierToResult = new Map<String, Result>();
     private static final Map<String, DmlMock> dmlIdentifierToMock = new Map<String, DmlMock>();
 
+    @NamespaceAccessible
     public DML() {
         this.configuration = new Configuration();
         this.strategiesStorage = new StrategiesStorage();
@@ -302,34 +321,42 @@ public inherited sharing class DML implements Commitable {
 
     // Insert
 
+    @NamespaceAccessible
     public Commitable toInsert(SObject record) {
         return this.toInsert(Record(record));
     }
 
+    @NamespaceAccessible
     public Commitable toInsert(Record record) {
         return this.registerInDependencyOrchestrator(this.getInsertStrategy(record.getSObjectType()), record);
     }
 
+    @NamespaceAccessible
     public Commitable toInsert(List<SObject> records) {
         return this.toInsert(Records(records));
     }
 
+    @NamespaceAccessible
     public Commitable toInsert(Records records) {
         return this.registerInDependencyOrchestrator(this.getInsertStrategy(records.getSObjectType()), records);
     }
 
+    @NamespaceAccessible
     public OperationResult insertImmediately(SObject record) {
         return this.insertImmediately(Record(record));
     }
 
+    @NamespaceAccessible
     public OperationResult insertImmediately(Record record) {
         return this.executeImmediately(this.getInsertStrategy(record.getSObjectType()), record);
     }
 
+    @NamespaceAccessible
     public OperationResult insertImmediately(List<SObject> records) {
         return this.insertImmediately(Records(records));
     }
 
+    @NamespaceAccessible
     public OperationResult insertImmediately(Records records) {
         return this.executeImmediately(this.getInsertStrategy(records.getSObjectType()), records);
     }
@@ -340,34 +367,42 @@ public inherited sharing class DML implements Commitable {
 
     // Update
 
+    @NamespaceAccessible
     public Commitable toUpdate(SObject record) {
         return this.toUpdate(Record(record));
     }
 
+    @NamespaceAccessible
     public Commitable toUpdate(Record record) {
         return this.registerInLinearOrchestrator(this.getUpdateStrategy(record.getSObjectType()), record);
     }
 
+    @NamespaceAccessible
     public Commitable toUpdate(List<SObject> records) {
         return this.toUpdate(Records(records));
     }
 
+    @NamespaceAccessible
     public Commitable toUpdate(Records records) {
         return this.registerInLinearOrchestrator(this.getUpdateStrategy(records.getSObjectType()), records);
     }
 
+    @NamespaceAccessible
     public OperationResult updateImmediately(SObject record) {
         return this.updateImmediately(Record(record));
     }
 
+    @NamespaceAccessible
     public OperationResult updateImmediately(Record record) {
         return this.executeImmediately(this.getUpdateStrategy(record.getSObjectType()), record);
     }
 
+    @NamespaceAccessible
     public OperationResult updateImmediately(List<SObject> records) {
         return this.updateImmediately(Records(records));
     }
 
+    @NamespaceAccessible
     public OperationResult updateImmediately(Records records) {
         return this.executeImmediately(this.getUpdateStrategy(records.getSObjectType()), records);
     }
@@ -378,43 +413,53 @@ public inherited sharing class DML implements Commitable {
 
     // Upsert
 
+    @NamespaceAccessible
     public Commitable toUpsert(SObject record) {
         return this.toUpsert(Record(record));
     }
 
+    @NamespaceAccessible
     public Commitable toUpsert(SObject record, SObjectField externalIdField) {
         return this.registerInDependencyOrchestrator(this.getUpsertStrategy(record.getSObjectType()).withExternalIdField(externalIdField), Record(record));
     }
 
+    @NamespaceAccessible
     public Commitable toUpsert(Record record) {
         return this.registerInDependencyOrchestrator(this.getUpsertStrategy(record.getSObjectType()), record);
     }
 
+    @NamespaceAccessible
     public Commitable toUpsert(List<SObject> records) {
         return this.toUpsert(Records(records));
     }
 
+    @NamespaceAccessible
     public Commitable toUpsert(List<SObject> records, SObjectField externalIdField) {
         Records dmlRecords = Records(records);
         return this.registerInDependencyOrchestrator(this.getUpsertStrategy(dmlRecords.getSObjectType()).withExternalIdField(externalIdField), dmlRecords);
     }
 
+    @NamespaceAccessible
     public Commitable toUpsert(Records records) {
         return this.registerInDependencyOrchestrator(this.getUpsertStrategy(records.getSObjectType()), records);
     }
 
+    @NamespaceAccessible
     public OperationResult upsertImmediately(SObject record) {
         return this.upsertImmediately(Record(record));
     }
 
+    @NamespaceAccessible
     public OperationResult upsertImmediately(Record record) {
         return this.executeImmediately(this.getUpsertStrategy(record.getSObjectType()), record);
     }
 
+    @NamespaceAccessible
     public OperationResult upsertImmediately(List<SObject> records) {
         return this.upsertImmediately(Records(records));
     }
 
+    @NamespaceAccessible
     public OperationResult upsertImmediately(Records records) {
         return this.executeImmediately(this.getUpsertStrategy(records.getSObjectType()), records);
     }
@@ -425,10 +470,12 @@ public inherited sharing class DML implements Commitable {
 
     // Delete
 
+    @NamespaceAccessible
     public Commitable toDelete(Id recordId) {
         return this.toDelete(Record(recordId));
     }
 
+    @NamespaceAccessible
     public Commitable toDelete(SObject record) {
         return this.toDelete(Record(record));
     }
@@ -437,10 +484,12 @@ public inherited sharing class DML implements Commitable {
         return this.registerInLinearOrchestrator(this.getDeleteStrategy(record.getSObjectType()), record);
     }
 
+    @NamespaceAccessible
     public Commitable toDelete(Iterable<Id> recordIds) {
         return this.toDelete(Records(recordIds));
     }
 
+    @NamespaceAccessible
     public Commitable toDelete(List<SObject> records) {
         return this.toDelete(Records(records));
     }
@@ -449,10 +498,12 @@ public inherited sharing class DML implements Commitable {
         return this.registerInLinearOrchestrator(this.getDeleteStrategy(records.getSObjectType()), records);
     }
 
+    @NamespaceAccessible
     public OperationResult deleteImmediately(Id recordId) {
         return this.deleteImmediately(Record(recordId));
     }
 
+    @NamespaceAccessible
     public OperationResult deleteImmediately(SObject record) {
         return this.deleteImmediately(Record(record));
     }
@@ -461,10 +512,12 @@ public inherited sharing class DML implements Commitable {
         return this.executeImmediately(this.getDeleteStrategy(record.getSObjectType()), record);
     }
 
+    @NamespaceAccessible
     public OperationResult deleteImmediately(Iterable<Id> recordIds) {
         return this.deleteImmediately(Records(recordIds));
     }
 
+    @NamespaceAccessible
     public OperationResult deleteImmediately(List<SObject> records) {
         return this.deleteImmediately(Records(records));
     }
@@ -479,21 +532,25 @@ public inherited sharing class DML implements Commitable {
 
     // Hard Delete
 
+    @NamespaceAccessible
     public Commitable toHardDelete(Id recordId) {
         Record dmlRecord = Record(recordId);
         return this.registerInLinearOrchestrator(this.getDeleteStrategy(dmlRecord.getSObjectType()).withHardDelete(), dmlRecord);
     }
 
+    @NamespaceAccessible
     public Commitable toHardDelete(SObject record) {
         Record dmlRecord = Record(record);
         return this.registerInLinearOrchestrator(this.getDeleteStrategy(dmlRecord.getSObjectType()).withHardDelete(), dmlRecord);
     }
 
+    @NamespaceAccessible
     public Commitable toHardDelete(Iterable<Id> recordIds) {
         Records dmlRecords = Records(recordIds);
         return this.registerInLinearOrchestrator(this.getDeleteStrategy(dmlRecords.getSObjectType()).withHardDelete(), dmlRecords);
     }
 
+    @NamespaceAccessible
     public Commitable toHardDelete(List<SObject> records) {
         Records dmlRecords = Records(records);
         return this.registerInLinearOrchestrator(this.getDeleteStrategy(dmlRecords.getSObjectType()).withHardDelete(), dmlRecords);
@@ -501,10 +558,12 @@ public inherited sharing class DML implements Commitable {
 
     // Undelete
 
+    @NamespaceAccessible
     public Commitable toUndelete(Id recordId) {
         return this.toUndelete(Record(recordId));
     }
 
+    @NamespaceAccessible
     public Commitable toUndelete(SObject record) {
         return this.toUndelete(Record(record));
     }
@@ -513,10 +572,12 @@ public inherited sharing class DML implements Commitable {
         return this.registerInLinearOrchestrator(this.getUndeleteStrategy(record.getSObjectType()), record);
     }
 
+    @NamespaceAccessible
     public Commitable toUndelete(Iterable<Id> recordIds) {
         return this.toUndelete(Records(recordIds));
     }
 
+    @NamespaceAccessible
     public Commitable toUndelete(List<SObject> records) {
         return this.toUndelete(Records(records));
     }
@@ -525,10 +586,12 @@ public inherited sharing class DML implements Commitable {
         return this.registerInLinearOrchestrator(this.getUndeleteStrategy(records.getSObjectType()), records);
     }
 
+    @NamespaceAccessible
     public OperationResult undeleteImmediately(Id recordId) {
         return this.undeleteImmediately(Record(recordId));
     }
 
+    @NamespaceAccessible
     public OperationResult undeleteImmediately(SObject record) {
         return this.undeleteImmediately(Record(record));
     }
@@ -537,10 +600,12 @@ public inherited sharing class DML implements Commitable {
         return this.executeImmediately(this.getUndeleteStrategy(record.getSObjectType()), record);
     }
 
+    @NamespaceAccessible
     public OperationResult undeleteImmediately(Iterable<Id> recordIds) {
         return this.undeleteImmediately(Records(recordIds));
     }
 
+    @NamespaceAccessible
     public OperationResult undeleteImmediately(List<SObject> records) {
         return this.undeleteImmediately(Records(records));
     }
@@ -555,11 +620,13 @@ public inherited sharing class DML implements Commitable {
 
     // Merge
 
+    @NamespaceAccessible
     public Commitable toMerge(SObject mergeToRecord, SObject duplicatedRecord) {
         Record dmlMergeToRecord = Record(mergeToRecord);
         return this.toMerge(this.getMergeStrategy(dmlMergeToRecord.getSObjectType(), dmlMergeToRecord), Record(duplicatedRecord));
     }
 
+    @NamespaceAccessible
     public Commitable toMerge(SObject mergeToRecord, Id duplicatedRecordId) {
         Record dmlMergeToRecord = Record(mergeToRecord);
         return this.toMerge(this.getMergeStrategy(dmlMergeToRecord.getSObjectType(), dmlMergeToRecord), Record(duplicatedRecordId));
@@ -569,11 +636,13 @@ public inherited sharing class DML implements Commitable {
         return this.registerInLinearOrchestrator(mergeStrategy, duplicatedRecord);
     }
 
+    @NamespaceAccessible
     public Commitable toMerge(SObject mergeToRecord, List<SObject> duplicateRecords) {
         Record dmlMergeToRecord = Record(mergeToRecord);
         return this.toMerge(this.getMergeStrategy(dmlMergeToRecord.getSObjectType(), dmlMergeToRecord), Records(duplicateRecords));
     }
 
+    @NamespaceAccessible
     public Commitable toMerge(SObject mergeToRecord, Iterable<Id> duplicatedRecordIds) {
         Record dmlMergeToRecord = Record(mergeToRecord);
         return this.toMerge(this.getMergeStrategy(dmlMergeToRecord.getSObjectType(), dmlMergeToRecord), Records(duplicatedRecordIds));
@@ -589,21 +658,25 @@ public inherited sharing class DML implements Commitable {
 
     // Platform Event
 
+    @NamespaceAccessible
     public Commitable toPublish(SObject record) {
         Record dmlRecord = Record(record);
         return this.registerInLinearOrchestrator(this.getPlatformEventStrategy(dmlRecord.getSObjectType()), dmlRecord);
     }
 
+    @NamespaceAccessible
     public Commitable toPublish(List<SObject> records) {
         Records dmlRecords = Records(records);
         return this.registerInLinearOrchestrator(this.getPlatformEventStrategy(dmlRecords.getSObjectType()), dmlRecords);
     }
 
+    @NamespaceAccessible
     public OperationResult publishImmediately(SObject record) {
         Record dmlRecord = Record(record);
         return this.executeImmediately(this.getPlatformEventStrategy(dmlRecord.getSObjectType()), dmlRecord);
     }
 
+    @NamespaceAccessible
     public OperationResult publishImmediately(List<SObject> records) {
         Records dmlRecords = Records(records);
         return this.executeImmediately(this.getPlatformEventStrategy(dmlRecords.getSObjectType()), dmlRecords);
@@ -655,6 +728,7 @@ public inherited sharing class DML implements Commitable {
 
     // Identifier
 
+    @NamespaceAccessible
     public Commitable identifier(String dmlIdentifier) {
         this.configuration.identifier(dmlIdentifier);
         return this;
@@ -662,16 +736,19 @@ public inherited sharing class DML implements Commitable {
 
     // Debug
 
+    @NamespaceAccessible
     public void preview() {
         this.configuration.preview();
     }
 
     // Field Level Security
 
+    @NamespaceAccessible
     public Commitable userMode() {
         return this.setAccessMode(System.AccessLevel.USER_MODE);
     }
 
+    @NamespaceAccessible
     public Commitable systemMode() {
         return this.setAccessMode(System.AccessLevel.SYSTEM_MODE);
     }
@@ -683,11 +760,13 @@ public inherited sharing class DML implements Commitable {
 
     // Sharing Mode
 
+    @NamespaceAccessible
     public Commitable withSharing() {
         this.configuration.withSharing();
         return this;
     }
 
+    @NamespaceAccessible
     public Commitable withoutSharing() {
         this.configuration.withoutSharing();
         return this;
@@ -695,26 +774,31 @@ public inherited sharing class DML implements Commitable {
 
     // Other configs
 
+    @NamespaceAccessible
     public Commitable allowPartialSuccess() {
         this.configuration.allowPartialSuccess();
         return this;
     }
 
+    @NamespaceAccessible
     public Commitable skipDuplicateRules() {
         this.configuration.skipDuplicateRules();
         return this;
     }
 
+    @NamespaceAccessible
     public Commitable combineOnDuplicate() {
         this.configuration.combineOnDuplicate();
         return this;
     }
 
+    @NamespaceAccessible
     public Commitable options(Database.DmlOptions options) {
         this.configuration.options(options);
         return this;
     }
 
+    @NamespaceAccessible
     public Commitable discardWork() {
         this.reset();
         return this;
@@ -722,11 +806,13 @@ public inherited sharing class DML implements Commitable {
 
     // Hooks
 
+    @NamespaceAccessible
     public Commitable commitHook(Hook callback) {
         this.hook = callback;
         return this;
     }
 
+    @NamespaceAccessible
     public Result dryRun() {
         Savepoint savePoint = Database.setSavepoint();
 
@@ -747,6 +833,7 @@ public inherited sharing class DML implements Commitable {
         }
     }
 
+    @NamespaceAccessible
     public Result commitWork() {
         DmlResult result = new DmlResult();
 
@@ -790,6 +877,7 @@ public inherited sharing class DML implements Commitable {
         dmlIdentifierToResult.put(this.configuration.dmlIdentifier, result);
     }
 
+    @NamespaceAccessible
     public Result commitTransaction() {
         if (!this.configuration.allOrNone) {
             throw new DmlException('commitTransaction() is not supported when allOrNone=false');
@@ -2094,6 +2182,7 @@ public inherited sharing class DML implements Commitable {
         }
     }
 
+    @NamespaceAccessible
     public class EnhancedRecord {
         private SObject currentRecord;
         private DmlStrategy strategy;


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
Allows public access points (old global classes, methods, and interfaces) to be used within namespace boundaries via @NamespaceAccessible

Same change that was applied to SOQL_lib
https://github.com/beyond-the-cloud-dev/soql-lib/pull/292

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Changes Made

<!-- List the specific changes made in this PR -->

- add `@NamespaceAccessible` annotation to public access points of lib

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Closes #

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [x] Tested in scratch org
- [ ] Linting passes (`npm run lint`)
- [x] Code formatting is correct (`npm run prettier:verify`)

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional information that reviewers should know -->
